### PR TITLE
Redirect `atsfmt`'s errors to nowhere.

### DIFF
--- a/ftplugin/ats.vim
+++ b/ftplugin/ats.vim
@@ -32,7 +32,7 @@ let g:syntastic_ats_checkers = [ 'patscc' ]
 function! AtsFormat()
     let cursor = getpos('.')
     exec 'normal! gg'
-    exec 'silent !atsfmt -i ' . expand('%')
+    exec 'silent !atsfmt -i ' . expand('%') . ' 2>/dev/null'
     exec 'e'
     call setpos('.', cursor)
 endfunction


### PR DESCRIPTION
We want automatic formatter to be silent. If it has an issue with the
code, it can either silently fix it or ignore; it is the job of
Syntastic to talk to us.

Writing to stderr seems to break Vim's rendering on some terminals.