### PR TITLE
Automatically insert comment leaders (*) for multi-line comments

### DIFF
--- a/ftplugin/ats.vim
+++ b/ftplugin/ats.vim
@@ -16,6 +16,12 @@ if !exists('g:ats_autoformat')
     endif
 endif
 
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal fo-=t fo+=croql
+
+setlocal comments=sr:/*,mb:*,ex:*/,sr:(*,mb:*,ex:*)
+
 " indentation rules
 set smarttab
 augroup ats


### PR DESCRIPTION
This adds support for automatically entering a leading `*` character when typing multiline `/* */` and `(* *)` comments, similarly to how `c.vim` does it.