### PR TITLE
Add support for additional syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/example
+/example_dats.c

--- a/example.dats
+++ b/example.dats
@@ -1,0 +1,770 @@
+/*
+ * Example DATS file
+ *
+ * This code is meant to provide an example of a bunch of different ATS syntax
+ * to help with testing changes to the syntax/ats.vim file.
+ *
+ * You can compile and run this file with:
+ *
+ *   % patscc -DATS_MEMALLOC_LIBC -o example example.dats -lrt
+ *   % ./example
+ *
+ */
+
+/*
+ * Examples of highlighting various file inclusion methods.
+ */
+#include "share/atspre_define.hats"
+#include "share/atspre_staload.hats"
+
+/*
+ * Examples of highlighting definition of names that have special
+ * meaning to the ATS compiler.
+ */
+#define ATS_PACKNAME "Example.kitchen_sink"
+#define ATS_EXTERN_PREFIX "kitchen_sink_"
+#define ATS_STATIC_PREFIX "_kitchen_sink_"
+
+%{^
+#include <alloca.h>
+#include <errno.h>
+%}
+
+#if 0 #then
+/*
+ * ATS supports a special environment variable, PATSHOMELOCS, which can be
+ * used at the beginning of a path to load. It should be called out via
+ * highlighting.
+ */
+#include "$PATSHOMELOCS/atscntrb-hx-globals/HATS/gcount.hats"
+#endif
+
+#define PRELUDE_targetloc "prelude/SATS"
+
+// You can use #staload or staload equivalently
+#staload UNSAFE = "{$PRELUDE}/unsafe.sats"
+staload UNSAFE = "{$PRELUDE}/unsafe.sats"
+
+// You can use already declared names
+staload UN = $UNSAFE
+staload $UN
+
+// You can use numbers, _, ', and $ in names.
+staload NOT0SAFE = $UNSAFE
+staload NOT_SAFE = $UNSAFE
+staload NOT'SAFE = $UNSAFE
+staload NOT$SAFE = $UNSAFE
+
+staload $NOT0SAFE
+staload $NOT_SAFE
+staload $NOT'SAFE
+staload $NOT$SAFE
+
+/*
+ * Example of highlighting preprocessor syntax.
+ */
+
+#ifdef FOO
+  #print "FOO is defined; undefining!\n"
+  #undef FOO
+#elifdef BAR
+  #prerr "BAR should not be defined!\n"
+#elifndef BAZ
+  #define BAZ 3
+#else
+  #assert (BAZ >= 1 && BAZ <= 5)
+#endif
+
+implement main0 () = ()
+
+/*
+ * Examples of highlighting constants.
+ */
+
+// Highlighting octal. The leading zero should be colored differently.
+val i: int 8 = 010
+val i: lint 8 = 010l
+val i: llint 8 = 010ll
+val i: uint 8 = 010u
+val i: ulint 8 = 010ul
+val i: ullint 8 = 010ull
+
+// Highlighting decimal.
+val i: int 10 = 10
+val i: lint 10 = 10l
+val i: llint 10 = 10ll
+val i: uint 10 = 10u
+val i: ulint 10 = 10ul
+val i: ullint 10 = 10ull
+
+// Highlighting hexadecimal.
+val i: int 16 = 0x10
+val i: lint 16 = 0x10l
+val i: llint 16 = 0x10ll
+val i: uint 16 = 0x10u
+val i: ulint 16 = 0x10ul
+val i: ullint 16 = 0x10ull
+
+// Highlighting floats.
+val f: float = 5.f
+val f: float = 5.0f
+val f: float = .5f
+val f: float = 0.5f
+val f: float = 5e-1f
+val f: float = 5e+1f
+val f: float = 5e10f
+val f: float = 5.e1f
+
+// Highlighting hex floats
+val xf: float = 0x5p10f
+val xf: float = 0x5p-10f
+val xf: float = 0x5p+10f
+val xf: float = 0x50.00p-1f
+
+// Highlighting doubles.
+val d: double = 2.
+val d: double = 2.0
+val d: double = .2
+val d: double = 0.2
+
+// Highlighting hex doubles
+val xd: double = 0x2p10
+val xd: double = 0x2p-10
+val xd: double = 0x2p+10
+val xd: double = 0x20.00p-1
+
+// Highlighting long doubles.
+val ld: ldouble = 2.l
+val ld: ldouble = 2.0l
+val ld: ldouble = .2l
+val ld: ldouble = 0.2l
+
+// Highlighting hex long doubles.
+val xld: ldouble = 0x2p10l
+val xld: ldouble = 0x2p-10l
+val xld: ldouble = 0x2p+10l
+val xld: ldouble = 0x20.00p-1l
+
+// It's okay for the suffix, exponent or hex "X" to be upper case.
+val i: ullint 8 = 010ULL
+val i: ullint 10 = 10ULL
+val i: ullint 16 = 0X10ULL
+val f: float = 5.F
+val f: float = 5E10F
+val d: ldouble = 2E10L
+val ld: ldouble = 2.E10l
+val xf: float = 0x5P10F
+val xd: double = 0x2P10
+val xld: ldouble = 0x2P10L
+
+// Or to place the "U" at the end.
+val i: ullint 8 = 010LLU
+val i: ullint 10 = 10LLU
+val i: ullint 16 = 0x10LLU
+
+// Highlighting strings.
+var str: string 2 = "\1234" // '4' is visually distinct from '\123'
+val str: string 11 = "foo\nbar\tbaz" // '\n' and '\t' are visually distinct
+val str: string 4 = "foo\\" // Literal backslash at end
+val str: string 5 = "foo\\\"" // Literal backslash and double quote at end
+
+// Highlighting normal characters.
+val c = 'a'
+
+// Highlighting special sequences.
+val c: char '\x07' = '\a'
+val c: char '\x08' = '\b'
+val c: char '\x0C' = '\f'
+val c: char '\x0A' = '\n'
+val c: char '\x0D' = '\r'
+val c: char '\x09' = '\t'
+val c: char '\x0B' = '\v'
+
+// Highlighting octal syntax.
+val c: char 'S' = '\123'
+val c: char 0 = '\0'
+
+// Highlighting octal syntax
+val c: char '~' = '\x7E'
+val c: char '~' = '\X7E'
+
+// Highlighting character literals (optional escaping).
+val c: char ')' = '\)'
+val c: char ']' = '\]'
+val c: char '}' = '\}'
+val c: char '"' = '\"'
+val c: char '?' = '\?'
+
+// Highlighting character literals (necessary escaping).
+val c: char '\x27' = '\''
+val c: char '\x28' = '\('
+val c: char '\x5B' = '\['
+val c: char '\x5C' = '\\'
+val c: char '\x7B' = '\{'
+
+// Boxed data whose contents are characters.
+val box_tup = '( 'a', 'b' )
+val box_rec = '{ a= 'a', b= 'b' }
+
+// Flat data
+var flat_tup = @( '@' )
+var flat_arr = @[char '@']( '@' )
+var flat_rec = @{ at= '@' }
+
+// Accessing fields. 
+val _ = flat_tup.0 // '.0' should not be highlighted like a float.
+val _ = flat_arr[0] // [] should be visually distinct from the identifier and 0
+val _ = flat_rec.at // '.' should be separate from the identifiers
+
+// "null" should be concealed with ∅, and highlighted as a constant when shown.
+val the_null_ptr: ptr null = $UN.cast{ptr null}0
+
+/*
+ * Examples of highlighting identifiers.
+ */
+
+val a = 5
+val A = 5
+val _a = 5
+val a_b = 5
+val a$b = 5
+val abcd = 5
+val a123 = 5
+val aA_12$ = 5
+val a'b = 5
+val a'b' = 5
+val a'b'c = 5
+val a' = 5
+val a'' = 5
+val a''' = 5
+val a'$'a' = 5
+val a'_'a' = 5
+
+// "abc" should be highlighted as an identifier after the addr@/view@ keywords.
+var abc = 5
+val a = addr@abc
+prval v = view@abc
+
+/*
+ * Examples of higlighting structured control flow.
+ */
+
+// if/then/else
+fun a {i: int} (i: int i): int (max(i + 10, 0)) =
+  if i < ~10 then
+    0
+  else i + 10
+
+// ifcase
+fun b {i: int} (i: int i): int (max(i + 10, 0)) =
+  ifcase
+  | i < ~10 => 0
+  | _ => i + 10
+
+// case
+fun c {n: int} (lst: !list_vt (int, n)): void =
+  case lst of
+  | list_vt_nil() => ()
+  | list_vt_cons(_, rest) => c(rest)
+
+// while loop
+fun fib1 {n: nat} (n: int n): int = let
+  var prev: int = 0
+  var curr: int = 1
+  var i: int = 0
+in
+  while (i < n) {
+    val next = prev + curr
+    val () = prev := curr
+    val () = curr := next
+    val () = i := i + 1
+  };
+
+  curr
+end
+
+// for loop
+fun fib2 {n: nat} (n: int n): int = let
+  var prev: int = 0
+  var curr: int = 1
+  var i: int
+in
+  for (i := 0; i < n; i := i + 1) {
+    val next = prev + curr
+    val () = prev := curr
+    val () = curr := next
+  };
+
+  curr
+end
+
+// for* loop
+fun fib3 {n: nat} (n: int n): int = let
+  var prev: int = 0
+  var curr: int = 1
+  var i: int
+in
+  for* {i: nat | i <= n} .<n-i>. (
+    i: int i
+  ) => (i := 0; i < n; i := i + 1) {
+    val next = prev + curr
+    val () = prev := curr
+    val () = curr := next
+  };
+
+  curr
+end
+
+macdef check_fib (i, o) = begin
+  assertloc(fib1(,(i)) = ,(o));
+  assertloc(fib2(,(i)) = ,(o));
+  assertloc(fib3(,(i)) = ,(o));
+end
+
+val () = check_fib(0, 1)
+val () = check_fib(1, 1)
+val () = check_fib(2, 2)
+val () = check_fib(3, 3)
+val () = check_fib(4, 5)
+val () = check_fib(5, 8)
+val () = check_fib(6, 13)
+
+// while* loop using the $break and $continue keywords
+fun bsearch {n: nat} (arr: &(@[int][n]), len: int n, v: int): Option (int) = let
+  var bounds: (Nat, Int) = (0, len - 1)
+  var idx: Option (Int) = None
+in
+  while* {l,u: int | 0 <= l; l <= u + 1; u + 1 <= n} .<u+1-l>. (
+    bounds: (int l, int u)
+  ) => 
+    (bounds.0 <= bounds.1) {
+    val+(lower, upper) = bounds
+    val middle = lower + half(upper - lower)
+    val sgn = compare(v, arr[middle])
+    val () =
+      if sgn = 0 then
+        (idx := Some(middle); $break)
+
+    typedef shrink (l: int, u: int) =
+      [
+        j,k: int
+      | j <= k + 1;
+        (l < j && u == k) || (l == j && k < u)
+      ] @(int j, int k)
+
+    val next =
+      (if sgn >= 0 then
+        (middle + 1, upper)
+      else (lower, middle - 1)): shrink (l, u)
+
+    val () = (bounds := next; $continue)
+  };
+
+  idx
+end
+
+#define LEN 11
+var arr = @[int][LEN](~10,~5,0,2,6,9,15,20,31,80,900)
+
+fun bsearch_test(arr: &(@[int][LEN]), v: int, exp: Option (int)): void = let
+  implement option_equal$eqfn<int>(a, b) = g0int_eq(a, b)
+
+  val res = bsearch(arr, LEN, v)
+in
+  assertloc(option_equal<int>(res, exp))
+end
+
+val () = bsearch_test(arr, ~10, Some(0))
+val () = bsearch_test(arr, ~5, Some(1))
+val () = bsearch_test(arr, 0, Some(2))
+val () = bsearch_test(arr, 2, Some(3))
+val () = bsearch_test(arr, 6, Some(4))
+val () = bsearch_test(arr, 9, Some(5))
+val () = bsearch_test(arr, 15, Some(6))
+val () = bsearch_test(arr, 20, Some(7))
+val () = bsearch_test(arr, 31, Some(8))
+val () = bsearch_test(arr, 80, Some(9))
+val () = bsearch_test(arr, 900, Some(10))
+val () = bsearch_test(arr, ~11, None)
+val () = bsearch_test(arr, ~9, None)
+val () = bsearch_test(arr, 19, None)
+val () = bsearch_test(arr, 21, None)
+
+/*
+ * Examples of highlighting macro definitions and syntax.
+ */
+
+macdef times2 (x) = let val y = ,(x) in (y + y) end
+macdef times4 (x) = let val y = ,(x) in times2 (y + y) end
+
+val () = println! (times4 (4))
+
+macrodef rec fact (x) =
+  if x = 0 then `(1) else `(%(x) * ,(fact (x - 1)))
+
+val () = assertloc (,(fact (5)) = 120)
+
+macrodef rec power(x, n) =
+  if n = 0 then `(1) else `(,(x) * ,(power (x, n - 1)))
+
+fun pow3 (x: Int): Int = ,(power (`(x), 3))
+fun pow4 (x: Int): Int = ,(power (`(x), 4))
+
+val () = assertloc (pow3(5) = 125)
+val () = assertloc (pow4(4) = 256)
+
+/*
+ * Examples of highlighting various constructors.
+ */
+
+datatype A (t: t@ype) =
+  | A_some (t) of (t)
+  | A_none (t) of ()
+
+dataview V (v: view+, bool) =
+  | V_some (v, true) of (v)
+  | V_none (v, false) of ()
+
+dataviewtype VT (t: t@ype+, bool) =
+  | VT_some (t, true) of (t)
+  | VT_none (t, false) of ()
+
+datasort mynat =
+  | Succ of (mynat)
+  | Zero of ()
+
+dataprop EVEN (mynat) =
+  | EVENbas (Zero ()) of ()
+  | {n: mynat}
+    EVENind (Succ (Succ (n))) of (EVEN (n))
+
+
+/*
+ * Examples of highlighting type definitions.
+ */
+
+sortdef four = {a: int | a == 4}
+
+stadef five = 5
+sexpdef six = 6
+
+typedef returns5 = () -<> int five
+typedef returns6 = () -<> int six
+
+propdef mul5 = [m,p: int] MUL (m, five, p)
+
+viewtypedef VTfive (b: bool) = VT (int five, b)
+vtypedef VTstrfive (b: bool) = VT (string (five), b)
+
+viewdef VfiveatL (l: addr, b: bool) = V (int five @ l, b)
+
+tkindef kindexmpl = "atstype_uint8";
+
+
+/*
+ * Examples of highlighting abstract type definitions.
+ */
+
+// abstract boxed type
+abstbox absptr
+abstype absptr
+
+// abstract flat type
+abstflt absint
+abstflat absint
+abst@ype absint
+abst0ype absint
+
+// linear abstract boxed type
+absvtype absintptr
+absvtbox absintptr
+absviewtype absintptr
+
+// linear abstract flat type
+absvtflt absvtat
+absvtflat absvtat
+absvt@ype absvtat
+absvt0ype absvtat
+absviewt@ype absvtat
+absviewt0ype absvtat
+
+// abstract view
+absview myview
+
+// abstract proposition
+absprop MYPROP
+
+local
+  absimpl absptr = ptr
+in
+  var a = 5
+  val b: absptr = addr@a
+end
+
+local
+  absreimpl absptr
+in
+  var a = 5
+  val b: absptr = addr@a
+end
+
+local
+  assume absintptr = [l: addr] (int @ l | ptr l)
+in
+  var a = 5
+  val b: absintptr = (view@a | addr@a)
+end
+
+local
+  reassume absintptr
+in
+  var a = 5
+  val b: absintptr = (view@a | addr@a)
+end
+
+/*
+ * Examples of highlighting withtype and friends.
+ */
+
+fun id1 (n) = n
+  withtype {n: nat} int (n) -> [i: nat | i == n] int (i)
+
+val vtn = VT_none ()
+  withvtype VT (string, false)
+
+val vtn = VT_some ("foo")
+  withviewtype VT (string, true)
+
+prval mul = mul_make {5,2} ()
+  withprop MUL (5, 2, 10)
+
+prval vn = V_none ()
+  withview [l: addr] V (int @ l, false)
+
+/*
+ * Examples of highlighting exception-related keywords.
+ */
+
+exception Error of ()
+
+fun throws1 (): void =
+  $raise (Error())
+
+fun throws2 (): void =
+  raise (Error())
+
+fun catches1 (): void =
+  try throws1() with ~Error() => throws2()
+
+/*
+ * Examples of highlighting debugging-related keywords.
+ */
+
+val (_) = $showtype (5) // Print the type of 5 at compile time.
+
+val () = println! ("the source file is ", $myfilename)
+val () = println! ("this println! is located at ", $mylocation)
+
+/*
+ * Examples of highlighting functions with effects.
+ */
+
+fun pure1 .<>. ():<fun0> void = ()
+
+fun pure2 .<>. ():<fun,0> void = ()
+
+fun pure3 .<>. ():<fun,!nil> void = ()
+
+fun pure4 .<>. ():<fun,1,~all> void = ()
+
+fun effectful1 ():<fun1> void = ()
+
+fun effectful2 ():<fun,1> void = ()
+
+fun nonterm1 ():<fun0,!ntm> void =
+  nonterm1 ()
+
+fun exceptional1 .<>. (a: int):<fun0,!exn> void =
+  $raise Error ()
+
+fun writing1 .<>. ():<fun0,!wrt> void =
+  ()
+
+fun referrer1 .<>. ():<fun0,!ref> void =
+  ()
+
+typedef exnfun (t1: t@ype, t2: t@ype) = t1 -<fun0,!exn> t2
+val f: exnfun (int, void) = exceptional1
+
+typedef exnclo (t1: t@ype, t2: t@ype) = t1 -<clo0,!exn> t2
+val f: exnclo (int, void) =
+  lam@ (i: int) =<clo,0,!exn> if i > 5 then $raise Error () else ()
+
+typedef exncloref (t1: t@ype, t2: t@ype) = t1 -<cloref0,!exn> t2
+val f: exncloref (int, void) =
+  lam (i: int) =<cloref,0,!exn> if i > 5 then $raise Error () else ()
+
+vtypedef exncloptr (t1: t@ype, t2: t@ype) = t1 -<cloptr0,!exn> t2
+val f: exncloptr (int, void) =
+  lam (i: int) =<cloptr,0,!exn> if i > 5 then $raise Error () else ()
+
+typedef fefun (t1: t@ype, t2: t@ype, fe: eff) = t1 -<fun,fe> t2
+typedef nilfun = fefun (int, int, effnil)
+typedef allfun = fefun (int, int, effall)
+typedef ntmfun = fefun (int, int, effntm)
+typedef exnfun = fefun (int, int, effexn)
+typedef reffun = fefun (int, int, effref)
+typedef wrtfun = fefun (int, int, effwrt)
+
+/*
+ * Examples of highlighting effect-masking keywords.
+ */
+
+fun masked_exn .<>. ():<fun0> void =
+  $effmask_exn (exceptional1 (1))
+
+fun masked_wrt .<>. ():<fun0> void =
+  $effmask_wrt (writing1 ())
+
+fun masked_ref .<>. ():<fun0> void =
+  $effmask_ref (referrer1 ())
+
+fun masked_all .<>. ():<fun0> void =
+  $effmask_all (effectful1 ())
+
+fun masked_ntm .<>. ():<fun0> void =
+  $effmask {!ntm} (nonterm1 ())
+
+/*
+ * Examples of highlighting C blocks.
+ */
+
+%{^
+/*
+ * The "%{^" syntax introduces a C block that will be placed at the top of
+ * the generated C file, and should be highlighted as Special.
+ *
+ * Code inside here is highlighted using C syntax highlighting.
+ */
+#include <stdlib.h>
+
+typedef struct plbc {
+	int plbc_i;
+	void (*plbc_f)(int, char *, void *);
+} PercentLBracketCaret;
+%}
+
+%{$
+/*
+ * The "%{$" syntax introduces a C block that will be placed at the end of
+ * the generated C file, and should be highlighted as Special.
+ *
+ * Code inside here is highlighted using C syntax highlighting.
+ */
+#include <stdlib.h>
+
+typedef struct plbd {
+	int plbd_i;
+	void (*plbd_f)(int, char *, void *);
+} PercentLBracketDollar;
+%}
+
+%{#
+/*
+ * The "%{#" syntax introduces a C block (usually in a *.sats file) that will
+ * be placed inside the generated C file of *.dats files that staload it.
+ */
+#include <stdlib.h>
+
+typedef struct plbh {
+	int plbh_i;
+	void (*plbh_f)(int, char *, void *);
+} PercentLBracketHash;
+%}
+
+%{
+/*
+ * The "%{" syntax introduces a C block that will be placed in an unspecified
+ * location somewhere within the generated C file, and should be highlighted
+ * as special.
+ *
+ * Code inside here is highlighted using C syntax highlighting.
+ */
+#include <stdlib.h>
+
+typedef struct plb {
+	int plb_i;
+	void (*plb_f)(int, char *, void *);
+} PercentLBracket;
+%}
+
+
+/*
+ * Examples of working with external types.
+ */
+
+typedef PercentLBracket = $extype "PercentLBracket"
+typedef PercentLBracketCaret = $extype_struct "PercentLBracketCaret" of {
+  plb_i= int,
+  plb_f= (int, string, ptr) -> void
+}
+
+
+/*
+ * Examples of working with external values.
+ */
+
+extvar "errno" = 0
+val errno = $extval(int, "errno")
+val _ = $extfcall(int, "printf", "first printf example: %.3s, %0*d\n", "aaab", 4, 5)
+
+extern fun printf {ts: types} (string, ts): int = "mac#"
+val _ = printf("second printf example: %.3s, %0*d\n", $vararg("aaab", 4, 5))
+
+
+/*
+ * Here are some examples of comments.
+ */
+
+/*
+ * Comments can contain the text TODO, FIXME, and XXX, which should
+ * be highlighted (probably in a yellowish color).
+ *
+ * If spellchecking is turned on in Vim (:set spell), then words like
+ * foobarbaz should be be highlighted (probably in a reddish color).
+ */
+
+// This is a double-slash comment, which ends at the end of the line.
+
+val a = 5 // This is a double-slash comment after a statement.
+val a = 5 /* This is a slash-star comment after a statement. */
+val a = 5 (* This is a paren-star comment after a statement. *)
+
+/*
+ * This is a multi-line slash-star comment.
+ */
+val a = 5
+
+(*
+ * This is a multi-line paren-star comment.
+ *)
+val a = 5
+
+(*
+
+Paren-star comments can be nested:
+
+(* This is the definition for `a'. *)
+val a = 5;
+
+This is still a comment.
+
+*)
+val a = 5
+
+////
+
+Above is an end of file comment. Everything in the rest of this file should
+be highlighted as a commment. For example:
+
+fun foo (): int = 5

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -170,7 +170,7 @@ syntax match logicalOr '||' conceal cchar=∨
 syntax match nullPtr 'null' conceal cchar=∅
 
 syn include @c syntax/c.vim
-syn region cBlock matchgroup=atsCBlock start="%{\|%{^\|%{#" end="%}" contains=@c
+syn region cBlock matchgroup=atsCBlock start="%{[#^$]\=" end="%}" contains=@c
 
 highlight link Conceal Keyword
 

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -61,6 +61,39 @@ syn region atsExQuantRight matchgroup=atsExQuant start="|" end="]" contains=TOP 
 
 syn match atsKeyword "\v[\+\-\<\>\=!\:\~]+"
 
+syn region atsLoadPath start=+"+ end=+"+ contains=atsLoadPathHomeLocs,atsLoadPathNgurl contained keepend
+syn match atsLoadPathHomeLocs "\"\@<=\$PATSHOMELOCS" contained
+syn region atsLoadPathNgurl start="\"\@<={" end="}" contained
+
+syn match atsStaload "^#\=staload" nextgroup=atsStaloadDecl,atsStaloadNS,atsLoadPath skipwhite skipnl
+syn match atsStaloadDecl "\<\(\w\|\$\|\'\)\+\s*=" nextgroup=atsStaloadNS,atsLoadPath contained skipwhite
+syn match atsStaloadNS "\<\$\(\w\|\$\|\'\)\+" contained
+
+syn match atsDynload "^#\=dynload" nextgroup=atsLoadPath skipwhite skipnl
+syn match atsInclude "^#include" nextgroup=atsLoadPath skipwhite skipnl
+syn match atsRequire "^#require" nextgroup=atsLoadPath skipwhite skipnl
+
+syn match atsDefine "#define\>"
+syn match atsUndefine "#undef\>"
+
+syn keyword atsDefineSpecial ATS_PACKNAME ATS_EXTERN_PREFIX ATS_STATIC_PREFIX
+syn keyword atsDefineSpecial ATS_DYNLOADFLAG ATS_DYNLOADNAME ATS_MAINATSFLAG
+
+syn match atsPreCondit "#if\(def\|ndef\)\=\>"
+syn match atsPreCondit "#elif\(def\|ndef\)\=\>"
+syn match atsPreCondit "#then\>"
+syn match atsPreCondit "#else\>"
+syn match atsPreCondit "#endif\>"
+
+syn match atsPreProc "#error\>"
+syn match atsPreProc "#prerr\>"
+syn match atsPreProc "#print\>"
+syn match atsPreProc "#assert\>"
+syn match atsPreProc "#pragma\>"
+
+syn match atsNamespace "\<\$[a-zA-Z0-9_]*\.\@="
+
+
 syn keyword atsMacroDefine macdef macrodef
 syn region atsMacroEncode start="`(" end=")" contains=TOP
 syn region atsMacroDecode start=",(" end=")" contains=TOP
@@ -78,7 +111,7 @@ syn keyword atsFun lam lam@ llam fix fix@
 syn keyword atsFun fun fn fnx prfun prfn
 syn keyword atsFun castfn praxi
 
-syn keyword atsKeyword staload dynload overload symintr include
+syn keyword atsKeyword overload symintr
 syn keyword atsKeyword and as of let in begin end when where local
 syn keyword atsKeyword var val prval prvar extvar
 syn keyword atsKeyword $extval $extfcall $extmcall $vararg
@@ -152,8 +185,6 @@ syn keyword atsType absimpl absreimpl assume reassume
 syn keyword atsType implement implmnt primplement primplmnt extern static
 syn keyword atsType withprop withtype withview withvtype withviewtype
 
-syn region atsMacro start="\v^#" end="\v$" contains=atsString
-
 syn keyword atsBool true false
 
 syn region atsComment start="\/\/" end="$" contains=atsTodo,@Spell
@@ -196,6 +227,20 @@ highlight link atsPercOperator Operator
 
 highlight link atsCaseArrow Keyword
 highlight link atsCaseUnreachable Special
+
+highlight link atsStaload Include
+highlight link atsDynload Include
+highlight link atsInclude Include
+highlight link atsRequire Include
+highlight link atsLoadPath String
+highlight link atsLoadPathHomeLocs Special
+highlight link atsLoadPathNgurl Special
+
+highlight link atsDefine Define
+highlight link atsUndefine Define
+highlight link atsPreCondit PreCondit
+highlight link atsPreProc PreProc
+highlight link atsDefineSpecial PreProc
 
 highlight link atsMacroDefine Define
 highlight link atsMacroEncode Macro

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -7,11 +7,11 @@ if !exists('main_syntax')
   let main_syntax = 'ats'
 endif
 
-syn iskeyword @,48-57,192-255,$,_,@-@
+syn iskeyword @,48-57,192-255,$,*,_,@-@
 
 syn keyword atsTodo TODO FIXME XXX contained
 
-syn match atsIdentifier "\v[a-zA-Z][a-zA-Z_0-9]*"
+syn match atsIdentifier "\(\w\|\$\)\@<!\h\(\w\|\$\|\'\)*"
 
 syn match atsInt "\c\<\d\+\(u\=l\{0,2}\|ll\=u\)\>"
 syn match atsHex "\c\<0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
@@ -40,17 +40,36 @@ syn match atsChar "\i\@<!'[^\\]'"
 syn match atsChar "\i\@<!'\\[^']*'" contains=atsSpecial
 
 syn region atsString start=+"+ end=+"+ contains=atsSpecial
-syn keyword atsKeyword staload dynload overload with fun symintr include fn fnx and prfun prfn praxi castfn
-syn keyword atsKeyword as lam llam fix raise of var val prval if then else addr let in begin end when where local while for prvar sif
-syn keyword atsKeywordTwo case ifcase scase
-syn keyword atsKeyword macdef exception rec
+
+syn keyword atsConditional ifcase if then else case sif scase
+syn keyword atsException $raise raise try with
+
+syn keyword atsRepeat while while* for for*
+syn keyword atsKeyword $break $continue
+
+syn keyword atsDebug $myfilename $myfunction $mylocation $showtype
+
+syn keyword atsFun lam lam@ llam fix fix@
+syn keyword atsFun fun fn fnx prfun prfn
+syn keyword atsFun castfn praxi
+
+syn keyword atsKeyword staload dynload overload symintr include
+syn keyword atsKeyword and as of let in begin end when where local
+syn keyword atsKeyword var val prval prvar extvar
+syn keyword atsKeyword $extval $extfcall $extmcall $vararg
+syn keyword atsKeyword sizeof exception rec
+syn match atsKeyword "\(fold\|free\|view\|addr\)@"
+
+syn keyword atsKeyword lnot lor land lxor not xor
+syn keyword atsKeyword mod nmod ndiv
+syn keyword atsKeyword andalso orelse
 
 syn match atsKeyword "\v[\%\+\-\<\>\=!\:\~]+"
 
-syn keyword atsFixity infixr infixl prefix postfix
+syn keyword atsFixity infix infixr infixl nonfix prefix postfix
 
-syn match atsArrow '=/=>'
-syn match atsArrow '=/=>>'
+syn match atsCaseArrow '=>>\='
+syn match atsCaseUnreachable '=/=>>\='
 
 " These are the tags that are allowed in between -<>/:<>/=<>
 syn keyword atsFunTag fun clo cloptr cloref lin linfun linclo lincloptr prf contained
@@ -147,7 +166,15 @@ highlight link atsHex Number
 highlight link atsChar Character
 highlight link atsSpecial SpecialChar
 
-highlight link atsKeywordTwo Include
+highlight link atsCaseArrow Keyword
+highlight link atsCaseUnreachable Special
+
+highlight link atsConditional Conditional
+highlight link atsDebug Debug
+highlight link atsRepeat Repeat
+highlight link atsException Exception
+highlight link atsFun Keyword
+
 highlight link atsEffmask Statement
 highlight link atsFunTag Constant
 highlight link atsEffTag Constant

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -7,7 +7,8 @@ if !exists('main_syntax')
   let main_syntax = 'ats'
 endif
 
-syn keyword atsTodo TODO FIXME contained
+syn keyword atsTodo TODO FIXME XXX contained
+
 syn match atsIdentifier "\v[a-zA-Z][a-zA-Z_0-9]*"
 
 syn match atsInt "\c\<\d\+\(u\=l\{0,2}\|ll\=u\)\>"
@@ -61,9 +62,10 @@ syn region atsMacro start="\v^#" end="\v$" contains=atsString
 
 syn keyword atsBool true false
 
-syn match atsComment "\v\/\/.*$" contains=atsTodo,@Spell
+syn region atsComment start="\/\/" end="$" contains=atsTodo,@Spell
 syn region atsNestComment start="/\*" end="\*/" contains=atsNestComment,atsTodo,@Spell
 syn region atsNestParenComment start="(\*" end="\*)" contains=atsTodo,@Spell,atsNestParenComment
+syn region atsRestOfFileComment start="////" end="\%$" contains=atsTodo,@Spell
 
 syntax match logicalAnd '&&' conceal cchar=∧
 syntax match leq '<=' conceal cchar=≤
@@ -97,12 +99,15 @@ highlight link atsArrow Special
 highlight link atsFixity Underlined
 highlight link atsOperator Special
 highlight link atsSpecial Special
-highlight link atsComment Comment
-highlight link atsNestComment Comment
-highlight link atsNestParenComment Comment
 highlight link atsKeyword Keyword
 highlight link atsType Type
 highlight link atsIdentifier Identifier
+
+highlight link atsComment Comment
+highlight link atsNestComment Comment
+highlight link atsNestParenComment Comment
+highlight link atsRestOfFileComment Comment
+highlight link atsTodo Todo
 
 hi def link atsCBlock Special
 

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -29,8 +29,13 @@ syn match atsHexFloat "\c0x\x*\.\x\+p[-+]\=\d\+[fl]\=\>"
 " hex float/double/ldouble, with leading digits, optional dot, with exponent
 syn match atsHexFloat "\c0x\x\+\.\=p[-+]\=\d\+[fl]\=\>"
 
-syn match atsSpecial +\v\\['"nt\\{]+
-syn match atsSpecial -\v\\[0-9]+-
+syn match atsSpecial "\\[abfnrtv]" contained
+syn match atsSpecial "\\['\"?\\{}()\[\]]" contained
+syn match atsSpecial "\\\o\{1,3}" contained
+syn match atsSpecial "\\[xX][0-9A-F]\{1,2}" contained
+
+syn match atsChar "\i\@<!'[^\\]'"
+syn match atsChar "\i\@<!'\\[^']*'" contains=atsSpecial
 
 syn region atsString start=+"+ end=+"+ contains=atsSpecial
 syn keyword atsKeyword staload dynload overload with fun symintr include fn fnx and prfun prfn praxi castfn sortdef
@@ -56,7 +61,7 @@ syn keyword atsType implement primplmnt extern
 
 syn match atsParens "[()]"
 
-syn match atsOperator "\v[\@\'\#]"
+syn match atsOperator "\v[\@\#]"
 
 syn region atsMacro start="\v^#" end="\v$" contains=atsString
 
@@ -75,10 +80,6 @@ syntax match seq '==' conceal cchar=≡
 syntax match logicalOr '||' conceal cchar=∨
 syntax match nullPtr 'null' conceal cchar=∅
 
-syn match atsChar "\v'.'"
-syn match atsChar "\v'.*'" contains=atsSpecial
-syn match atsPattern "\v'\("
-
 syn include @c syntax/c.vim
 syn region cBlock matchgroup=atsCBlock start="%{\|%{^\|%{#" end="%}" contains=@c
 
@@ -93,12 +94,12 @@ highlight link atsOctal Number
 highlight link atsOctalZero SpecialChar
 highlight link atsHex Number
 highlight link atsChar Character
+highlight link atsSpecial SpecialChar
 
 highlight link atsKeywordTwo Include
 highlight link atsArrow Special
 highlight link atsFixity Underlined
 highlight link atsOperator Special
-highlight link atsSpecial Special
 highlight link atsKeyword Keyword
 highlight link atsType Type
 highlight link atsIdentifier Identifier

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -40,10 +40,10 @@ syn match atsChar "\i\@<!'[^\\]'"
 syn match atsChar "\i\@<!'\\[^']*'" contains=atsSpecial
 
 syn region atsString start=+"+ end=+"+ contains=atsSpecial
-syn keyword atsKeyword staload dynload overload with fun symintr include fn fnx and prfun prfn praxi castfn sortdef
+syn keyword atsKeyword staload dynload overload with fun symintr include fn fnx and prfun prfn praxi castfn
 syn keyword atsKeyword as lam llam fix raise of var val prval if then else addr let in begin end when where local while for prvar sif
 syn keyword atsKeywordTwo case ifcase scase
-syn keyword atsKeyword stadef sta stacst assume macdef exception rec
+syn keyword atsKeyword macdef exception rec
 
 syn match atsKeyword "\v[\%\+\-\<\>\=!\:\~]+"
 
@@ -74,10 +74,41 @@ syn region atsEffmaskArg start="{" end="}" contains=@atsEffList contained
 
 syn region atsArrow start="[-:=]<" end=">" contains=@atsEffList
 
-syn keyword atsType void bool string char int uint uint8 uint32 uint16 int8 int32 int16 charNZ strnptr Strptr0 Strptr1 nat lint ulint double float size_t
-syn keyword atsType datavtype datatype vtypedef dataviewtype viewtypdef typedef view viewdef dataview abstype absvtype absviewtype absview datasort dataprop type viewtype vtype propdef prop
-syn keyword atsType absimpl absprop
-syn keyword atsType implement primplmnt extern
+syn keyword atsType addr agz agez alez
+syn keyword atsType void real cls eff tkind types
+syn keyword atsType charNZ scharNZ ucharNZ
+syn keyword atsType sint usint lint ulint llint ullint double ldouble float pos
+syn keyword atsType size_t ssize_t
+syn keyword atsType Size_t SSize_t Size SSize
+syn keyword atsType int8 uint8 int16 uint16 int32 uint32 int64 uint64
+syn keyword atsType Int8 uInt8 Int16 uInt16 Int32 uInt32 Int64 uInt64
+syn keyword atsType bool ptr int uint nat char schar uchar string
+syn keyword atsType Bool Ptr Int uInt Nat Char sChar uChar String Sgn
+syn keyword atsType intptr uintptr strptr strnptr Strptr Strnptr
+syn keyword atsType Strptr0 Strptr1 Strnptr0 Strnptr1
+syn keyword atsType vtflt viewt@ype vt@ype viewt0ype vt0ype
+syn keyword atsType vtbox viewtype vtype
+syn keyword atsType tflt t@ype t0ype
+syn keyword atsType tbox type
+syn keyword atsType prop view
+
+syn keyword atsStructure datavtype datatype dataviewtype dataview datasort dataprop
+
+syn keyword atsTypedef sta stacst stadef sexpdef
+syn keyword atsTypedef typedef viewtypedef vtypedef
+syn keyword atsTypedef classdec propdef sortdef tkindef viewdef
+
+syn keyword atsTypedefAbs absvtflt absvtflat absviewt@ype absvt@ype absviewt0ype absvt0ype
+syn keyword atsTypedefAbs absvtbox absviewtype absvtype
+syn keyword atsTypedefAbs abstflt abstflat abst@ype abst0ype
+syn keyword atsTypedefAbs abstbox abstype
+syn keyword atsTypedefAbs absprop absview
+
+syn keyword atsTypedefExt $extkind $extype $extype_struct
+
+syn keyword atsType absimpl absreimpl assume reassume
+syn keyword atsType implement implmnt primplement primplmnt extern static
+syn keyword atsType withprop withtype withview withvtype withviewtype
 
 syn match atsParens "[()]"
 
@@ -126,8 +157,13 @@ highlight link atsArrow Special
 highlight link atsFixity Underlined
 highlight link atsOperator Special
 highlight link atsKeyword Keyword
-highlight link atsType Type
 highlight link atsIdentifier Identifier
+
+highlight link atsStructure Structure
+highlight link atsType Type
+highlight link atsTypedef Typedef
+highlight link atsTypedefAbs atsTypedef
+highlight link atsTypedefExt atsTypedef
 
 highlight link atsComment Comment
 highlight link atsNestComment Comment

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -198,7 +198,7 @@ syntax match geq '>=' conceal cchar=≥
 syntax match neq '!=' conceal cchar=≠
 syntax match seq '==' conceal cchar=≡
 syntax match logicalOr '||' conceal cchar=∨
-syntax match nullPtr 'null' conceal cchar=∅
+syntax match atsNullPtr '\<null\>' conceal cchar=∅
 
 syn include @c syntax/c.vim
 syn region cBlock matchgroup=atsCBlock start="%{[#^$]\=" end="%}" contains=@c
@@ -215,6 +215,7 @@ highlight link atsOctalZero SpecialChar
 highlight link atsHex Number
 highlight link atsChar Character
 highlight link atsSpecial SpecialChar
+highlight link atsNullPtr Constant
 
 highlight link atsRecBoxed atsRecord
 highlight link atsTupBoxed atsTuple

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -10,12 +10,23 @@ endif
 syn keyword atsTodo TODO FIXME contained
 syn match atsIdentifier "\v[a-zA-Z][a-zA-Z_0-9]*"
 
-syn match atsFloat "\v[0-9]+\.[0-9]+f"
-syn match atsDouble "\v[0-9]+\.[0-9]+"
+syn match atsInt "\c\<\d\+\(u\=l\{0,2}\|ll\=u\)\>"
+syn match atsHex "\c\<0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 
-syn match atsInt "\v[0-9]+"
-syn match atsUint "\v[0-9]+u"
-syn match atsHex "\v0x[0-9a-fA-F]+"
+" visually marking the leading 0 in octal syntax
+syn match atsOctal "\c\<0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=atsOctalZero
+syn match atsOctalZero "\<0" contained
+
+" float/double/ldouble, with dot, optional exponent
+syn match atsFloat "\c\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\="
+" float/double/ldouble, starting with a dot, optional exponent
+syn match atsFloat "\c\i\@<!\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
+" float/double/ldouble, without dot, with exponent
+syn match atsFloat "\c\d\+e[-+]\=\d\+[fl]\=\>"
+" hex float/double/ldouble, optional leading digits, with dot, with exponent
+syn match atsHexFloat "\c0x\x*\.\x\+p[-+]\=\d\+[fl]\=\>"
+" hex float/double/ldouble, with leading digits, optional dot, with exponent
+syn match atsHexFloat "\c0x\x\+\.\=p[-+]\=\d\+[fl]\=\>"
 
 syn match atsSpecial +\v\\['"nt\\{]+
 syn match atsSpecial -\v\\[0-9]+-
@@ -70,19 +81,22 @@ syn include @c syntax/c.vim
 syn region cBlock matchgroup=atsCBlock start="%{\|%{^\|%{#" end="%}" contains=@c
 
 highlight link Conceal Keyword
+
 highlight link atsBool Boolean
+highlight link atsString String
+highlight link atsFloat Float
+highlight link atsHexFloat Float
+highlight link atsInt Number
+highlight link atsOctal Number
+highlight link atsOctalZero SpecialChar
+highlight link atsHex Number
+highlight link atsChar Character
+
 highlight link atsKeywordTwo Include
 highlight link atsArrow Special
 highlight link atsFixity Underlined
 highlight link atsOperator Special
 highlight link atsSpecial Special
-highlight link atsString String
-highlight link atsUint Number
-highlight link atsInt Number
-highlight link atsHex Number
-highlight link atsFloat Number
-highlight link atsDouble Number
-highlight link atsChar Character
 highlight link atsComment Comment
 highlight link atsNestComment Comment
 highlight link atsNestParenComment Comment

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -41,6 +41,26 @@ syn match atsChar "\i\@<!'\\[^']*'" contains=atsSpecial
 
 syn region atsString start=+"+ end=+"+ contains=atsSpecial
 
+syn match atsAtOperator "@[({[]\@!"
+syn match atsPercOperator "%[({}]\@!"
+
+syn region atsParens start="['@`,%]\@<!(" end=")" contains=TOP
+
+syn region atsTupBoxed start="'(" end=")" contains=TOP
+syn region atsTupFlat start="@(" end=")" contains=TOP
+
+syn region atsRecBoxed start="'{" end="}" contains=TOP
+syn region atsRecFlat start="@{" end="}" contains=TOP
+
+syn region atsArrFlat matchgroup=atsArrFlat start="@\[" end="]" contains=TOP nextgroup=atsArrFlatSize,atsArrFlatElts
+syn region atsArrFlatSize matchgroup=atsArrFlat start="\[" end="]" nextgroup=atsArrFlatElts contains=TOP contained
+syn region atsArrFlatElts matchgroup=atsArrFlat start="(" end=")" contains=TOP contained
+
+syn region atsExQuantLeft matchgroup=atsExQuant start="#\[" end="]\||\@=" nextgroup=atsExQuantRight contains=TOP
+syn region atsExQuantRight matchgroup=atsExQuant start="|" end="]" contains=TOP contained
+
+syn match atsKeyword "\v[\+\-\<\>\=!\:\~]+"
+
 syn keyword atsConditional ifcase if then else case sif scase
 syn keyword atsException $raise raise try with
 
@@ -63,8 +83,6 @@ syn match atsKeyword "\(fold\|free\|view\|addr\)@"
 syn keyword atsKeyword lnot lor land lxor not xor
 syn keyword atsKeyword mod nmod ndiv
 syn keyword atsKeyword andalso orelse
-
-syn match atsKeyword "\v[\%\+\-\<\>\=!\:\~]+"
 
 syn keyword atsFixity infix infixr infixl nonfix prefix postfix
 
@@ -129,10 +147,6 @@ syn keyword atsType absimpl absreimpl assume reassume
 syn keyword atsType implement implmnt primplement primplmnt extern static
 syn keyword atsType withprop withtype withview withvtype withviewtype
 
-syn match atsParens "[()]"
-
-syn match atsOperator "\v[\@\#]"
-
 syn region atsMacro start="\v^#" end="\v$" contains=atsString
 
 syn keyword atsBool true false
@@ -166,6 +180,15 @@ highlight link atsHex Number
 highlight link atsChar Character
 highlight link atsSpecial SpecialChar
 
+highlight link atsRecBoxed atsRecord
+highlight link atsTupBoxed atsTuple
+highlight link atsRecFlat atsRecord
+highlight link atsTupFlat atsTuple
+highlight link atsArrFlat atsArray
+
+highlight link atsAtOperator Special
+highlight link atsPercOperator Operator
+
 highlight link atsCaseArrow Keyword
 highlight link atsCaseUnreachable Special
 
@@ -182,7 +205,6 @@ highlight link atsEffCst Constant
 highlight link atsEffOps Operator
 highlight link atsArrow Special
 highlight link atsFixity Underlined
-highlight link atsOperator Special
 highlight link atsKeyword Keyword
 highlight link atsIdentifier Identifier
 

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -7,6 +7,8 @@ if !exists('main_syntax')
   let main_syntax = 'ats'
 endif
 
+syn iskeyword @,48-57,192-255,$,_,@-@
+
 syn keyword atsTodo TODO FIXME XXX contained
 
 syn match atsIdentifier "\v[a-zA-Z][a-zA-Z_0-9]*"
@@ -47,12 +49,30 @@ syn match atsKeyword "\v[\%\+\-\<\>\=!\:\~]+"
 
 syn keyword atsFixity infixr infixl prefix postfix
 
-syn keyword arrowContents cloref1 cloptr1 lincloptr cloref cloptr
 syn match atsArrow '=/=>'
 syn match atsArrow '=/=>>'
 
-syn region atsArrow start="=<" end=">" contains=arrowContents
-syn region atsArrow start="-<" end=">"
+" These are the tags that are allowed in between -<>/:<>/=<>
+syn keyword atsFunTag fun clo cloptr cloref lin linfun linclo lincloptr prf contained
+syn keyword atsFunTag fun0 clo0 cloptr0 cloref0 lin0 linfun0 linclo0 lincloptr0 contained
+syn keyword atsFunTag fun1 clo1 cloptr1 cloref1 lin1 linfun1 linclo1 lincloptr1 contained
+
+" These are the effect tags that are allowed in between -<>/:<>/=<>
+syn keyword atsEffTag nil all ntm nonterm exn exception ref reference wrt write contained
+syn keyword atsEffTag exnref exnwrt exnrefwrt refwrt laz contained
+
+" These are the effect static constant identifiers
+syn keyword atsEffCst effnil effall effntm effexn effref effwrt
+
+syn match atsEffOps "[~!]" contained
+
+syn cluster atsEffList contains=atsFunTag,atsEffTag,atsEffOps,atsInt,atsIdentifier
+
+syn keyword atsEffmask $effmask $effmask_all $effmask_exn $effmask_ref $effmask_wrt
+syn keyword atsEffmask $effmask nextgroup=atsEffmaskArg skipwhite skipnl
+syn region atsEffmaskArg start="{" end="}" contains=@atsEffList contained
+
+syn region atsArrow start="[-:=]<" end=">" contains=@atsEffList
 
 syn keyword atsType void bool string char int uint uint8 uint32 uint16 int8 int32 int16 charNZ strnptr Strptr0 Strptr1 nat lint ulint double float size_t
 syn keyword atsType datavtype datatype vtypedef dataviewtype viewtypdef typedef view viewdef dataview abstype absvtype absviewtype absview datasort dataprop type viewtype vtype propdef prop
@@ -97,6 +117,11 @@ highlight link atsChar Character
 highlight link atsSpecial SpecialChar
 
 highlight link atsKeywordTwo Include
+highlight link atsEffmask Statement
+highlight link atsFunTag Constant
+highlight link atsEffTag Constant
+highlight link atsEffCst Constant
+highlight link atsEffOps Operator
 highlight link atsArrow Special
 highlight link atsFixity Underlined
 highlight link atsOperator Special

--- a/syntax/ats.vim
+++ b/syntax/ats.vim
@@ -61,6 +61,11 @@ syn region atsExQuantRight matchgroup=atsExQuant start="|" end="]" contains=TOP 
 
 syn match atsKeyword "\v[\+\-\<\>\=!\:\~]+"
 
+syn keyword atsMacroDefine macdef macrodef
+syn region atsMacroEncode start="`(" end=")" contains=TOP
+syn region atsMacroDecode start=",(" end=")" contains=TOP
+syn region atsMacroXStage start="%(" end=")" contains=TOP
+
 syn keyword atsConditional ifcase if then else case sif scase
 syn keyword atsException $raise raise try with
 
@@ -191,6 +196,11 @@ highlight link atsPercOperator Operator
 
 highlight link atsCaseArrow Keyword
 highlight link atsCaseUnreachable Special
+
+highlight link atsMacroDefine Define
+highlight link atsMacroEncode Macro
+highlight link atsMacroDecode Macro
+highlight link atsMacroXStage Macro
 
 highlight link atsConditional Conditional
 highlight link atsDebug Debug


### PR DESCRIPTION
This PR adds support for additional ATS syntax and keywords to the `syntax/ats.vim` file, and adds an `example.dats` file which includes different syntax examples and keywords.

I've grouped the changes into commits that should hopefully make this easier to review. If you'd prefer this split this into multiple PRs, please let me know.