### PR TITLE
Avoid creating *.c files

### DIFF
--- a/syntax_checkers/ats/patscc.vim
+++ b/syntax_checkers/ats/patscc.vim
@@ -5,11 +5,10 @@ let g:loaded_syntastic_ats_patscc_checker = 1
 
 let g:syntastic_ats_patscc_exec = 'patscc'
 
-" TODO optionally include -ccats flag for quicker response
 function! SyntaxCheckers_ats_patscc_GetLocList() dict
     let makeprg = self.makeprgBuild({
                 \ 'exe': self.getExec(),
-                \ 'args': '-DATS_MEMALLOC_LIBC -cleanaft -o /tmp/patscc-vim',
+                \ 'args': '-DATS_MEMALLOC_LIBC -cleanaft -tcats -o /tmp/patscc-vim',
                 \ 'fname': shellescape(expand('%') )})
 
     let errorformat =


### PR DESCRIPTION
I noticed that the current command invocation was creating `*_dats.c` and `*_sats.c` files in my Vim's current working directory, despite the `-cleanaft` flag. Adding the `-tcats` file avoids generating the `*.c` files, and still reports errors.